### PR TITLE
set perms on swapfile and script

### DIFF
--- a/aws-swap-init
+++ b/aws-swap-init
@@ -94,6 +94,7 @@ start () {
         
     # OK, time to get down to business.
     /bin/dd if=/dev/zero of=$TARGET/swapfile00 bs=1024 count=$SIZE
+    /bin/chmod 0600 $TARGET/swapfile00
     /sbin/mkswap $TARGET/swapfile00
     /sbin/swapon $TARGET/swapfile00
 }


### PR DESCRIPTION
Amazon Linux now complains about the permissions on the swapfile.

```
# service aws-swap-init start
524288+0 records in
524288+0 records out
536870912 bytes (537 MB) copied, 2.71449 s, 198 MB/s
Setting up swapspace version 1, size = 524284 KiB
no label, UUID=094d0b7d-631f-47cf-824f-376100f5321e
swapon: /swapfile00: insecure permissions 0644, 0600 suggested.
```

This is a simple tweak to set the right perms. I also set the script to be executable.
